### PR TITLE
Reuse the RPC response to avoid duplication

### DIFF
--- a/SolanaDemoApp.xcodeproj/project.pbxproj
+++ b/SolanaDemoApp.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		06967D5A264F977B0066A104 /* RPCResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06967D59264F977B0066A104 /* RPCResponse.swift */; };
 		7E0CE92626238342006F0E8E /* Double+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E0CE90026238342006F0E8E /* Double+.swift */; };
 		7E0CE92726238342006F0E8E /* Int+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E0CE90126238342006F0E8E /* Int+.swift */; };
 		7E0CE92826238342006F0E8E /* JSON+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E0CE90226238342006F0E8E /* JSON+.swift */; };
@@ -54,6 +55,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		06967D59264F977B0066A104 /* RPCResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RPCResponse.swift; sourceTree = "<group>"; };
 		7E0CE90026238342006F0E8E /* Double+.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Double+.swift"; sourceTree = "<group>"; };
 		7E0CE90126238342006F0E8E /* Int+.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Int+.swift"; sourceTree = "<group>"; };
 		7E0CE90226238342006F0E8E /* JSON+.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "JSON+.swift"; sourceTree = "<group>"; };
@@ -183,6 +185,7 @@
 				7E0CE91526238342006F0E8E /* GetConfirmedTransaction.swift */,
 				7E0CE91626238342006F0E8E /* GetEpochInfo.swift */,
 				7E0CE91726238342006F0E8E /* SimulateTransaction.swift */,
+				06967D59264F977B0066A104 /* RPCResponse.swift */,
 			);
 			path = "Requests and Responses";
 			sourceTree = "<group>";
@@ -337,6 +340,7 @@
 				7E0CE93026238342006F0E8E /* GetBalanace.swift in Sources */,
 				7E0CE94326238342006F0E8E /* Networking.swift in Sources */,
 				7E0CE93326238342006F0E8E /* GetClusterNodes.swift in Sources */,
+				06967D5A264F977B0066A104 /* RPCResponse.swift in Sources */,
 				7E0CE92A26238342006F0E8E /* Account.swift in Sources */,
 				7E0CE92C26238342006F0E8E /* Encoding.swift in Sources */,
 				7E0CE93126238342006F0E8E /* GetBlockCommitment.swift in Sources */,

--- a/Sources/Solana/Models/Requests and Responses/GetAccountInfo.swift
+++ b/Sources/Solana/Models/Requests and Responses/GetAccountInfo.swift
@@ -8,12 +8,7 @@
 import Foundation
 
 // MARK: - Response
-public struct GetAccountInfoResponse: Codable {
-    let jsonrpc: String
-    let result: GetAccountInfoResult
-    let id: Int
-    let error: RpcError?
-}
+public typealias GetAccountInfoResponse = RPCResponse<GetAccountInfoResult>
 
 public struct GetAccountInfoResult: Codable {
     let context: GetAccountInfoContext

--- a/Sources/Solana/Models/Requests and Responses/GetBalanace.swift
+++ b/Sources/Solana/Models/Requests and Responses/GetBalanace.swift
@@ -8,12 +8,7 @@
 import Foundation
 
 // MARK: - Response
-public struct GetBalanceResponse: Codable {
-    let jsonrpc: String
-    let result: GetBalanceResult
-    let id: Int
-    let error: RpcError?
-}
+public typealias GetBalanceResponse = RPCResponse<GetBalanceResult>
 
 public struct GetBalanceResult: Codable {
     let context: GetBalanceContext

--- a/Sources/Solana/Models/Requests and Responses/GetBlockCommitment.swift
+++ b/Sources/Solana/Models/Requests and Responses/GetBlockCommitment.swift
@@ -8,12 +8,7 @@
 import Foundation
 
 // MARK: - Response
-public struct GetBlockCommitmentResponse: Codable {
-    let jsonrpc: String
-    let result: GetBlockCommitmentResult
-    let id: Int
-    let error: RpcError?
-}
+public typealias GetBlockCommitmentResponse = RPCResponse<GetBlockCommitmentResult>
 
 public struct GetBlockCommitmentResult: Codable {
     let commitment: [Int]?

--- a/Sources/Solana/Models/Requests and Responses/GetBlockTime.swift
+++ b/Sources/Solana/Models/Requests and Responses/GetBlockTime.swift
@@ -8,9 +8,4 @@
 import Foundation
 
 // MARK: - Response
-public struct GetBlockTimeResponse: Codable {
-    let id: Int
-    let jsonrpc: String
-    let result: Int?
-    let error: RpcError?
-}
+public typealias GetBlockTimeResponse = RPCResponse<Int?>

--- a/Sources/Solana/Models/Requests and Responses/GetClusterNodes.swift
+++ b/Sources/Solana/Models/Requests and Responses/GetClusterNodes.swift
@@ -8,12 +8,7 @@
 import Foundation
 
 // MARK: - Response
-public struct GetClusterNodesResponse: Codable {
-    let jsonrpc: String
-    let result: [GetClusterNodesResult]
-    let id: Int
-    let error: RpcError?
-}
+public typealias GetClusterNodesResponse = RPCResponse<[GetClusterNodesResult]>
 
 public struct GetClusterNodesResult: Codable {
     let featureSet: UInt64?

--- a/Sources/Solana/Models/Requests and Responses/GetConfirmedBlock.swift
+++ b/Sources/Solana/Models/Requests and Responses/GetConfirmedBlock.swift
@@ -8,12 +8,7 @@
 import Foundation
 
 // MARK: - Response
-public struct GetConfirmedBlockResponse: Codable {
-    let jsonrpc: String
-    let result: GetConfirmedBlockResult
-    let id: Int
-    let error: RpcError?
-}
+public typealias GetConfirmedBlockResponse = RPCResponse<GetConfirmedBlockResult>
 
 public struct GetConfirmedBlockResult: Codable {
     let blockTime: Int64?

--- a/Sources/Solana/Models/Requests and Responses/GetConfirmedBlocks.swift
+++ b/Sources/Solana/Models/Requests and Responses/GetConfirmedBlocks.swift
@@ -8,9 +8,4 @@
 import Foundation
 
 // MARK: - Response
-public struct GetConfirmedBlocksResponse: Codable {
-    let jsonrpc: String
-    let result: [UInt64]
-    let id: Int
-    let error: RpcError?
-}
+public typealias GetConfirmedBlocksResponse = RPCResponse<[UInt64]>

--- a/Sources/Solana/Models/Requests and Responses/GetConfirmedBlocksWithLimit.swift
+++ b/Sources/Solana/Models/Requests and Responses/GetConfirmedBlocksWithLimit.swift
@@ -8,9 +8,4 @@
 import Foundation
 
 // MARK: - Response
-public struct GetConfirmedBlocksWithLimitResponse: Codable {
-    let jsonrpc: String
-    let result: [UInt64]
-    let id: Int
-    let error: RpcError?
-}
+public typealias GetConfirmedBlocksWithLimitResponse = RPCResponse<[UInt64]>

--- a/Sources/Solana/Models/Requests and Responses/GetConfirmedSignaturesForAddress.swift
+++ b/Sources/Solana/Models/Requests and Responses/GetConfirmedSignaturesForAddress.swift
@@ -8,9 +8,4 @@
 import Foundation
 
 // MARK: - Response
-public struct GetConfirmedSignaturesForAddressResponse: Codable {
-    let jsonrpc: String
-    let result: [String]
-    let id: Int
-    let error: RpcError?
-}
+public typealias GetConfirmedSignaturesForAddressResponse = RPCResponse<[String]>

--- a/Sources/Solana/Models/Requests and Responses/GetConfirmedSignaturesForAddress2.swift
+++ b/Sources/Solana/Models/Requests and Responses/GetConfirmedSignaturesForAddress2.swift
@@ -14,12 +14,7 @@ public struct GetConfirmedSignaturesForAddress2Config: Codable {
 }
 
 // MARK: - Response
-public struct GetConfirmedSignaturesForAddress2Response: Codable {
-    let jsonrpc: String
-    let result: [GetConfirmedSignaturesForAddress2Result]
-    let id: Int
-    let error: RpcError?
-}
+public typealias GetConfirmedSignaturesForAddress2Response = RPCResponse<[GetConfirmedSignaturesForAddress2Result]>
 
 public struct GetConfirmedSignaturesForAddress2Result: Codable {
     let blockTime: Int64?

--- a/Sources/Solana/Models/Requests and Responses/GetConfirmedTransaction.swift
+++ b/Sources/Solana/Models/Requests and Responses/GetConfirmedTransaction.swift
@@ -8,12 +8,7 @@
 import Foundation
 
 // MARK: - Response
-public struct GetConfirmedTransactionResponse: Codable {
-    let jsonrpc: String
-    let result: GetConfirmedTransactionResult?
-    let id: Int
-    let error: RpcError?
-}
+public typealias GetConfirmedTransactionResponse = RPCResponse<GetConfirmedTransactionResult>
 
 public struct GetConfirmedTransactionResult: Codable {
     let slot: UInt64

--- a/Sources/Solana/Models/Requests and Responses/GetEpochInfo.swift
+++ b/Sources/Solana/Models/Requests and Responses/GetEpochInfo.swift
@@ -8,14 +8,9 @@
 import Foundation
 
 // MARK: - Response
-public struct GetEpochInfoResponse: Codable {
-    let jsonrpc: String
-    let result: GetEpochInfoResult
-    let id: Int
-    let error: RpcError?
-}
+public typealias GetEpochInfoResponse = RPCResponse<GetEpochInfoResult>
 
-struct GetEpochInfoResult: Codable {
+public struct GetEpochInfoResult: Codable {
     let absoluteSlot: UInt64
     let blockHeight: UInt64
     let epoch: UInt64

--- a/Sources/Solana/Models/Requests and Responses/GetEpochSchedule.swift
+++ b/Sources/Solana/Models/Requests and Responses/GetEpochSchedule.swift
@@ -1,0 +1,8 @@
+//
+//  GetEpochSchedule.swift
+//  SolanaDemoApp
+//
+//  Created by Arturo Jamaica on 2021/05/15.
+//
+
+import Foundation

--- a/Sources/Solana/Models/Requests and Responses/RPCResponse.swift
+++ b/Sources/Solana/Models/Requests and Responses/RPCResponse.swift
@@ -1,0 +1,15 @@
+//
+//  RPCResponse.swift
+//  SolanaDemoApp
+//
+//  Created by Arturo Jamaica on 2021/05/15.
+//
+
+import Foundation
+
+public struct RPCResponse<T: Codable>: Codable {
+    let jsonrpc: String
+    let result: T
+    let id: Int
+    let error: RpcError?
+}

--- a/Sources/Solana/Models/Requests and Responses/SimulateTransaction.swift
+++ b/Sources/Solana/Models/Requests and Responses/SimulateTransaction.swift
@@ -20,12 +20,7 @@ public struct SimulateTransactionConfig: Codable {
 }
 
 // MARK: - Response
-public struct SimulateTransactionResponse: Codable {
-    let jsonrpc: String
-    let result: SimulateTransactionResult
-    let id: Int
-    let error: RpcError?
-}
+public typealias SimulateTransactionResponse = RPCResponse<SimulateTransactionResult>
 
 public struct SimulateTransactionResult: Codable {
     let context: SimulateTransactionContext


### PR DESCRIPTION
This PR will Remove all the response and hide them on a typealias to reuse one object using generics.